### PR TITLE
Update html-quiz.md

### DIFF
--- a/html/html-quiz.md
+++ b/html/html-quiz.md
@@ -773,8 +773,8 @@ From [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hr): The HT
 
 #### Q47. Which choice is NOT a legal value for the **name** attribute within a `<meta>` tag?
 
-- [x] charset
-- [ ] viewport
+- [ ] charset
+- [x] viewport
 - [ ] generator
 - [ ] author
 


### PR DESCRIPTION
The use of the 'charset' value in the name attribute is entirely valid and necessary to indicate the character encoding used in the document. 

'viewport' is not a legal value for the name attribute within a <meta> tag.